### PR TITLE
StepDetector requires the ACTIVITY_RECOGNITION permission

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
 
     <!-- Required for Sound Level Detector only -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <!-- Required for Step Detector only -->
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
 
     <application
         android:icon="@mipmap/ic_launcher"

--- a/sample/src/main/java/com/github/nisrulz/senseysample/MainActivity.kt
+++ b/sample/src/main/java/com/github/nisrulz/senseysample/MainActivity.kt
@@ -299,7 +299,19 @@ class MainActivity :
 
                 resources.getString(R.string.step_detector) ->
                     if (isChecked) {
-                        it.startStepDetection(this, this, StepDetectorUtil.MALE)
+                        if (RuntimePermissionUtil.checkPermissonGranted(
+                                this@MainActivity,
+                                permission.ACTIVITY_RECOGNITION,
+                            )
+                        ) {
+                            it.startStepDetection(this, this, StepDetectorUtil.MALE)
+                        } else {
+                            RuntimePermissionUtil.requestPermission(
+                                this,
+                                permission.ACTIVITY_RECOGNITION,
+                                0,
+                            )
+                        }
                     } else {
                         it.stopStepDetection(this)
                     }


### PR DESCRIPTION
The app didn't work on my Android 16 device. This permission is required for the step counter to work, however, it's only available in later API versions. Not sure what to do about that.
> Field requires API level 29 (current min is 21): android.Manifest.permission#ACTIVITY_RECOGNITION

